### PR TITLE
Mirror of netty netty#10408

### DIFF
--- a/common/src/main/java/io/netty/util/internal/PlatformDependent.java
+++ b/common/src/main/java/io/netty/util/internal/PlatformDependent.java
@@ -1146,6 +1146,8 @@ public final class PlatformDependent {
                     case 'g': case 'G':
                         maxDirectMemory *= 1024 * 1024 * 1024;
                         break;
+                    default:
+                        break;
                 }
                 break;
             }

--- a/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
+++ b/transport/src/main/java/io/netty/channel/nio/NioEventLoop.java
@@ -738,6 +738,8 @@ public final class NioEventLoop extends SingleThreadEventLoop {
                     invokeChannelUnregistered(task, k, null);
                 }
                 break;
+            default:
+                 break;
             }
         }
     }


### PR DESCRIPTION
Mirror of netty netty#10408
Motivation:

In io.netty.channel.nio.NioEventLoop processSelectedKey(java.nio.channels.SelectionKey, io.netty.channel.nio.NioTask<java.nio.channels.SelectableChannel>),The default statement is missing in the switch case.please review the pr,thk.

Modification:

Fix switch case fail through in NioEventLoop

Result:


If there is no issue then describe the changes introduced by this PR.

