### PR TITLE
Mirror of netty netty#10418

### DIFF
--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java
@@ -49,6 +49,10 @@ public final class Http2SecurityUtil {
      */
     private static final List<String> CIPHERS_JAVA_MOZILLA_MODERN_SECURITY = Collections.unmodifiableList(Arrays
             .asList(
+            /* openssl = ECDHE-ECDSA-AES128-GCM-SHA256 */
+            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+            /* openssl = ECDHE-RSA-AES128-GCM-SHA256 */
+            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
             /* openssl = ECDHE-ECDSA-AES256-GCM-SHA384 */
             "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
             /* openssl = ECDHE-RSA-AES256-GCM-SHA384 */
@@ -56,14 +60,7 @@ public final class Http2SecurityUtil {
             /* openssl = ECDHE-ECDSA-CHACHA20-POLY1305 */
             "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
             /* openssl = ECDHE-RSA-CHACHA20-POLY1305 */
-            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256",
-            /* openssl = ECDHE-ECDSA-AES128-GCM-SHA256 */
-            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
-
-            /* REQUIRED BY HTTP/2 SPEC */
-            /* openssl = ECDHE-RSA-AES128-GCM-SHA256 */
-            "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
-            /* REQUIRED BY HTTP/2 SPEC */
+            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
             ));
 
     static {

--- a/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java
+++ b/codec-http2/src/main/java/io/netty/handler/codec/http2/Http2SecurityUtil.java
@@ -51,8 +51,12 @@ public final class Http2SecurityUtil {
             .asList(
             /* openssl = ECDHE-ECDSA-AES128-GCM-SHA256 */
             "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+
+            /* REQUIRED BY HTTP/2 SPEC */
             /* openssl = ECDHE-RSA-AES128-GCM-SHA256 */
             "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+            /* REQUIRED BY HTTP/2 SPEC */
+
             /* openssl = ECDHE-ECDSA-AES256-GCM-SHA384 */
             "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
             /* openssl = ECDHE-RSA-AES256-GCM-SHA384 */


### PR DESCRIPTION
Mirror of netty netty#10418
Motivation:

From the recent benchmark using gRPC-Java based on Netty's HTTP2, it appears that it prefers `ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256` over `ECDHE_ECDSA_WITH_AES_128_GCM_SHA256` since it uses the Netty HTTPS Cipher list as is. Both are considered safe but `ECDHE_ECDSA_WITH_AES_128_GCM_SHA256` has a good chance to get more optimized implementation. (e.g. AES-NI) When running both on GCP Intel Haswell VM, `TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256` spent 3x CPU time than `TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256`. (Note that this VM supports AES-NI)

From the cipher suites listed on `Intermediate compatibility (recommended)` of [Security/Server Side TLS](https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility), they have a cipher preference which is aligned with this PR.

```
0x13,0x01  -  TLS_AES_128_GCM_SHA256         TLSv1.3  Kx=any   Au=any    Enc=AESGCM(128)             Mac=AEAD
0x13,0x02  -  TLS_AES_256_GCM_SHA384         TLSv1.3  Kx=any   Au=any    Enc=AESGCM(256)             Mac=AEAD
0x13,0x03  -  TLS_CHACHA20_POLY1305_SHA256   TLSv1.3  Kx=any   Au=any    Enc=CHACHA20/POLY1305(256)  Mac=AEAD
0xC0,0x2B  -  ECDHE-ECDSA-AES128-GCM-SHA256  TLSv1.2  Kx=ECDH  Au=ECDSA  Enc=AESGCM(128)             Mac=AEAD
0xC0,0x2F  -  ECDHE-RSA-AES128-GCM-SHA256    TLSv1.2  Kx=ECDH  Au=RSA    Enc=AESGCM(128)             Mac=AEAD
0xC0,0x2C  -  ECDHE-ECDSA-AES256-GCM-SHA384  TLSv1.2  Kx=ECDH  Au=ECDSA  Enc=AESGCM(256)             Mac=AEAD
0xC0,0x30  -  ECDHE-RSA-AES256-GCM-SHA384    TLSv1.2  Kx=ECDH  Au=RSA    Enc=AESGCM(256)             Mac=AEAD
0xCC,0xA9  -  ECDHE-ECDSA-CHACHA20-POLY1305  TLSv1.2  Kx=ECDH  Au=ECDSA  Enc=CHACHA20/POLY1305(256)  Mac=AEAD
0xCC,0xA8  -  ECDHE-RSA-CHACHA20-POLY1305    TLSv1.2  Kx=ECDH  Au=RSA    Enc=CHACHA20/POLY1305(256)  Mac=AEAD
0x00,0x9E  -  DHE-RSA-AES128-GCM-SHA256      TLSv1.2  Kx=DH    Au=RSA    Enc=AESGCM(128)             Mac=AEAD
0x00,0x9F  -  DHE-RSA-AES256-GCM-SHA384      TLSv1.2  Kx=DH    Au=RSA    Enc=AESGCM(256)             Mac=AEAD
```

Modification:

Moving up `AES_128_GCM_SHA256` in the CIPHERS of HTTPS so that it gets priority.

Result:

When connecting to the server supporting both `ECDHE_ECDSA_WITH_AES_128_GCM_SHA256` and `ECDSA_WITH_CHACHA20_POLY1305_SHA256` and respecting the client priority of cipher suites, it will be able to save significant cpu time when running it on machines with AES-NI support.
